### PR TITLE
do not register 'fixrtm.all_permit' and permissions starting with 'negative.'

### DIFF
--- a/src/main/java/com/anatawa12/pluginPermsForNgt/NGTPermissionManagerBukkit.java
+++ b/src/main/java/com/anatawa12/pluginPermsForNgt/NGTPermissionManagerBukkit.java
@@ -58,6 +58,10 @@ public class NGTPermissionManagerBukkit extends PermissionManager implements IPe
 
     @Vendors(Vendor.PluginPermsForNgt)
     private void doRegisterPermission(String per1) {
+        if (per1.equals("fixrtm.all_permit") || per1.startsWith("negative.")) {
+            PluginPermsForNgtMain.log("ignored registerPermission: " + per1);
+            return;
+        }
         DefaultPermissions.registerPermission(PERM_PREFIX + per1, 
                 "The permission of ngtlib permission " + per1);
         PluginPermsForNgtMain.log("registerPermission: " + per1);


### PR DESCRIPTION
Fixes #10 